### PR TITLE
Bug fix of issue #8

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -19,20 +19,24 @@
     "@angular/core": "^4.0.0",
     "@angular/forms": "^4.0.0",
     "@angular/http": "^4.0.0",
-    "@angular/material": "^2.0.0-beta.10",
     "@angular/platform-browser": "^4.0.0",
     "@angular/platform-browser-dynamic": "^4.0.0",
     "@angular/router": "^4.0.0",
-    "@types/socket.io-client": "~1.4.30",
+    "@types/socket.io-client": "~1.4.29",
+    "@types/express": "~4.0.36",
+    "express": "~4.10.0",
+    "@angular/material": "^2.0.0-beta.12",
     "core-js": "^2.4.1",
     "hammerjs": "^2.0.8",
     "rxjs": "^5.1.0",
-    "zone.js": "^0.8.4"
+    "zone.js": "^0.8.4",
+    "socket.io": "~2.0.3"
   },
   "devDependencies": {
-    "@angular/cli": "1.2.0",
+    "@angular/cli": "^1.5.0",
     "@angular/compiler-cli": "^4.0.0",
     "@angular/language-service": "^4.0.0",
+    "@angular/material": "^2.0.0-beta.12",
     "@types/jasmine": "~2.5.53",
     "@types/jasminewd2": "~2.0.2",
     "@types/node": "~6.0.60",
@@ -48,6 +52,6 @@
     "protractor": "~5.1.2",
     "ts-node": "~3.0.4",
     "tslint": "~5.3.2",
-    "typescript": "~2.3.3"
+    "typescript": "~2.5.0"
   }
 }

--- a/client/package.json
+++ b/client/package.json
@@ -25,7 +25,6 @@
     "@types/socket.io-client": "~1.4.29",
     "@types/express": "~4.0.36",
     "express": "~4.10.0",
-    "@angular/material": "^2.0.0-beta.12",
     "core-js": "^2.4.1",
     "hammerjs": "^2.0.8",
     "rxjs": "^5.1.0",

--- a/client/src/app/app.module.ts
+++ b/client/src/app/app.module.ts
@@ -2,13 +2,7 @@ import { BrowserModule } from '@angular/platform-browser';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { NgModule } from '@angular/core';
 
-import { MdIconModule,
-         MdInputModule,
-         MdButtonModule,
-         MdSidenavModule,
-         MdToolbarModule,
-         MdListModule,
-        } from '@angular/material';
+import { MatIconModule, MatInputModule, MatButtonModule, MatSidenavModule, MatToolbarModule, MatListModule, } from '@angular/material';
 
 import { AppRoutingModule } from './app-routing.module';
 import { AppComponent } from './app.component';
@@ -22,12 +16,12 @@ import { ChatModule } from './chat/chat.module';
     BrowserModule,
     BrowserAnimationsModule,
     AppRoutingModule,
-    MdButtonModule,
-    MdIconModule,
-    MdInputModule,
-    MdSidenavModule,
-    MdToolbarModule,
-    MdListModule,
+    MatButtonModule,
+    MatIconModule,
+    MatInputModule,
+    MatSidenavModule,
+    MatToolbarModule,
+    MatListModule,
     ChatModule
   ],
   providers: [],

--- a/client/src/app/chat/chat.component.ts
+++ b/client/src/app/chat/chat.component.ts
@@ -1,5 +1,5 @@
 import { Component, OnInit } from '@angular/core';
-import { MdDialog, MdDialogRef } from '@angular/material';
+import { MatDialog, MatDialogRef } from '@angular/material';
 
 import { Action } from '../shared/action';
 import { Message } from '../shared/message.model';
@@ -22,7 +22,7 @@ export class ChatComponent implements OnInit {
   messages: Message[] = [];
   messageContent: string;
   ioConnection: any;
-  dialogRef: MdDialogRef<DialogUserComponent> | null;
+  dialogRef: MatDialogRef<DialogUserComponent> | null;
   defaultDialogUserParams: any = {
     disableClose: true,
     data: {
@@ -32,7 +32,7 @@ export class ChatComponent implements OnInit {
   };
 
   constructor(private socketService: SocketService,
-    public dialog: MdDialog) { }
+    public dialog: MatDialog) { }
 
   ngOnInit(): void {
     this.initModel();

--- a/client/src/app/chat/chat.module.ts
+++ b/client/src/app/chat/chat.module.ts
@@ -2,13 +2,13 @@ import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import {
-  MdButtonModule,
-  MdCardModule,
-  MdDialog,
-  MdDialogModule,
-  MdIconModule,
-  MdInputModule,
-  MdListModule,
+  MatButtonModule,
+  MatCardModule,
+  MatDialog,
+  MatDialogModule,
+  MatIconModule,
+  MatInputModule,
+  MatListModule,
 } from '@angular/material';
 
 import { ChatComponent } from './chat.component';
@@ -19,16 +19,16 @@ import { DialogUserComponent } from '../dialog-user/dialog-user.component';
   imports: [
     CommonModule,
     FormsModule,
-    MdButtonModule,
-    MdCardModule,
-    MdDialogModule,
-    MdIconModule,
-    MdInputModule,
-    MdListModule,
+    MatButtonModule,
+    MatCardModule,
+    MatDialogModule,
+    MatIconModule,
+    MatInputModule,
+    MatListModule,
     ReactiveFormsModule
   ],
   declarations: [ChatComponent, DialogUserComponent],
-  providers: [MdDialog, SocketService],
+  providers: [MatDialog, SocketService],
   entryComponents: [DialogUserComponent]
 })
 export class ChatModule { }

--- a/client/src/app/dialog-user/dialog-user.component.ts
+++ b/client/src/app/dialog-user/dialog-user.component.ts
@@ -1,5 +1,5 @@
 import { Component, OnInit, Inject } from '@angular/core';
-import { MdDialogRef, MD_DIALOG_DATA } from '@angular/material';
+import { MatDialogRef, MAT_DIALOG_DATA } from '@angular/material';
 import { FormControl, Validators } from '@angular/forms';
 
 @Component({
@@ -11,8 +11,8 @@ export class DialogUserComponent implements OnInit {
   usernameFormControl = new FormControl('', [Validators.required]);
   previousUsername: string;
 
-  constructor(public dialogRef: MdDialogRef<DialogUserComponent>,
-    @Inject(MD_DIALOG_DATA) public params: any) {
+  constructor(public dialogRef: MatDialogRef<DialogUserComponent>,
+    @Inject(MAT_DIALOG_DATA) public params: any) {
     this.previousUsername = params.username ? params.username : undefined;
   }
 

--- a/client/src/main.ts
+++ b/client/src/main.ts
@@ -1,4 +1,4 @@
-import { enableProdMode } from '@angular/core';
+  import { enableProdMode } from '@angular/core';
 import { platformBrowserDynamic } from '@angular/platform-browser-dynamic';
 
 import { AppModule } from './app/app.module';


### PR DESCRIPTION
Refactored these files so that the imports in the client works. It currently tries importing material modules with the prefix 
MdMatname, whereas it should be like so:
```javascript
import { MatButtonModule } from '@angular/core'
```

Some of the errors that were given when trying to build the client side was:

ERROR in Error: MdButtonModule is not an NgModule
(this error came in a bunch of variations, in fact all material modules, that were referenced).

The client side of the example app, now works by following the original instructions to build.

This commit and PR sets out to resolve issue #8.