### PR TITLE
fixed issue with  TS2304: Cannot find name 'Symbol'

### DIFF
--- a/server/tsconfig.json
+++ b/server/tsconfig.json
@@ -5,6 +5,7 @@
   ],
   "compilerOptions": {
     "noImplicitAny": true,
-    "target": "es5"
+    "target": "es5",
+    "lib": [ "dom", "es2015" ]
   }
 }


### PR DESCRIPTION
During _gulp build_ one error occured:

`[22:10:47] Using gulpfile ~/Downloads/socket-io-typescript-chat/server/gulpfile.js
[22:10:47] Starting 'build'...
Compiler option 'compileOnSave' requires a value of type boolean.
/home/xxx/downloads/socket-io-typescript-chat/server/node_modules/@types/node/util.d.ts(113,88): error TS2304: Cannot find name 'Symbol'.
[22:10:49] TypeScript: 1 semantic error
[22:10:49] TypeScript: emit succeeded (with errors)
[22:10:49] Finished 'build' after 1.17 s`